### PR TITLE
fix a unperfect define of .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+
 /*
 !/app/
 /app/*
@@ -5,11 +14,3 @@
 /app/src/*
 !/app/src/main/
 !/.gitignore
-Thumbs.db
-ehthumbs.db
-Desktop.ini
-$RECYCLE.BIN/
-.DS_Store
-.AppleDouble
-.LSOverride
-Icon


### PR DESCRIPTION
mainly beacuse of the "DS_Store" files.

If the "*.DS_Store" is under the "/app/src/main...", the files with that suffix will be included in git which is don't be needed.